### PR TITLE
Fix: Corrige SyntaxError em ExecuteBackgroundProcessTool

### DIFF
--- a/app/tool/background_process_tools.py
+++ b/app/tool/background_process_tools.py
@@ -39,7 +39,7 @@ class ExecuteBackgroundProcessTool(BaseTool):
         "required": ["command", "log_file_stdout", "log_file_stderr"],
     }
 
-    async def execute(self, command: str, working_directory: Optional[str] = None, log_file_stdout: str, log_file_stderr: str, task_description: Optional[str] = None) -> Dict[str, Any]:
+    async def execute(self, command: str, log_file_stdout: str, log_file_stderr: str, working_directory: Optional[str] = None, task_description: Optional[str] = None) -> Dict[str, Any]:
         """
         Executes the given command in the background.
 


### PR DESCRIPTION
Corrigi um SyntaxError na assinatura do método `execute` da classe `ExecuteBackgroundProcessTool` em `app/tool/background_process_tools.py`.

O erro ocorria porque parâmetros sem valor padrão (`log_file_stdout`, `log_file_stderr`) estavam posicionados após parâmetros com valor padrão (`working_directory`). Ajustei a ordem dos parâmetros para resolver este problema de sintaxe.

**Funcionalidades**
<!-- Descreva as funcionalidades ou correções de bugs neste PR. Para correções de bugs, vincule à issue. -->

- Funcionalidade 1
- Funcionalidade 2

**Documentação da Funcionalidade**
<!-- Forneça links de RFC, tutorial ou caso de uso para atualizações significativas. Opcional para pequenas alterações. -->

**Impacto**
<!-- Explique o impacto dessas alterações para o foco do revisor. -->

**Resultado**
<!-- Inclua capturas de tela ou logs de testes unitários ou resultados de execução. -->

**Outro**
<!-- Notas adicionais sobre este PR. -->
