### PR TITLE
Add agent assignment to checklist tasks

### DIFF
--- a/app/agent/checklist_manager.py
+++ b/app/agent/checklist_manager.py
@@ -1,11 +1,11 @@
-from pathlib import Path
-from typing import List, Dict, Optional
 import re
+from typing import Dict, List, Optional
 
-from app.tool.file_operators import LocalFileOperator
-from app.exceptions import ToolError
 from app.config import config
+from app.exceptions import ToolError
 from app.logger import logger
+from app.tool.file_operators import LocalFileOperator
+
 
 class ChecklistManager:
     """
@@ -22,7 +22,11 @@ class ChecklistManager:
         """
         self.checklist_path = config.workspace_root / checklist_filename
         logger.info(f"ChecklistManager initialized for: {self.checklist_path}")
-        self.tasks: List[Dict[str, str]] = []  # e.g., [{'description': 'Do X', 'status': 'Pendente'}]
+        self.tasks: List[
+            Dict[str, str]
+        ] = (
+            []
+        )  # e.g., [{'description': 'Do X', 'status': 'Pendente', 'agent': 'Manus'}]
         self.file_operator = LocalFileOperator()
         # _load_checklist will be called explicitly by the tool after instantiation if needed.
 
@@ -43,27 +47,40 @@ class ChecklistManager:
             # No specific check for "File not found" in content needed here,
             # as FileNotFoundError will be caught below if read_file raises it.
 
-            if not content: # Handles empty file content
-                logger.info(f"Checklist file at {self.checklist_path} is empty. Initializing with empty task list.")
+            if not content:  # Handles empty file content
+                logger.info(
+                    f"Checklist file at {self.checklist_path} is empty. Initializing with empty task list."
+                )
                 self.tasks = []
                 return
 
-            self.tasks = [] # Reset tasks before loading
-            # Pattern to match: - [Status] Description
+            self.tasks = []  # Reset tasks before loading
+            # Pattern to match: - [Status] [Agent: NAME] Description (agent part optional)
             # Status can be Pendente, Em Andamento, Concluído, Bloqueado (case insensitive)
-            task_pattern = re.compile(r"-\s*\[(Pendente|Em Andamento|Concluído|Bloqueado)\]\s*(.+)", re.IGNORECASE)
+            task_pattern = re.compile(
+                r"-\s*\[(Pendente|Em Andamento|Concluído|Bloqueado)\]\s*(?:\[Agente:\s*(?P<agent>[^\]]+)\]\s*)?(?P<desc>.+)",
+                re.IGNORECASE,
+            )
             for line_number, line in enumerate(content.splitlines()):
                 line = line.strip()
-                if not line: # Skip empty lines
+                if not line:  # Skip empty lines
                     continue
                 match = task_pattern.match(line)
                 if match:
-                    status = match.group(1).capitalize() # Ensure consistent capitalization (e.g., "concluído" -> "Concluído")
-                    description = match.group(2).strip()
-                    self.tasks.append({'description': description, 'status': status})
+                    status = match.group(1).capitalize()  # Normalize status
+                    agent = match.group("agent")
+                    description = match.group("desc").strip()
+                    task_entry = {
+                        "description": description,
+                        "status": status,
+                        "agent": agent.strip() if agent else None,
+                    }
+                    self.tasks.append(task_entry)
                 else:
                     # Log lines that don't match the expected format
-                    logger.warning(f"Could not parse checklist line: '{line}' in file {self.checklist_path} at line {line_number + 1}. Skipping.")
+                    logger.warning(
+                        f"Could not parse checklist line: '{line}' in file {self.checklist_path} at line {line_number + 1}. Skipping."
+                    )
 
             logger.info(f"Loaded {len(self.tasks)} tasks from {self.checklist_path}.")
 
@@ -82,35 +99,48 @@ class ChecklistManager:
             # Given the current structure (ToolError wrapping), we stick to string checking for "File not found"
             if "File not found" in str(e) or "No such file or directory" in str(e):
                 # This is the specific log message requested by the issue for FileNotFoundError
-                logger.info(f"Arquivo de checklist '{self.checklist_path}' não encontrado. Iniciando com uma checklist vazia.")
+                logger.info(
+                    f"Arquivo de checklist '{self.checklist_path}' não encontrado. Iniciando com uma checklist vazia."
+                )
             else:
                 # Log other ToolErrors
-                logger.error(f"ToolError occurred while reading checklist file {self.checklist_path}: {e}")
-            self.tasks = [] # Initialize with empty list for any ToolError
+                logger.error(
+                    f"ToolError occurred while reading checklist file {self.checklist_path}: {e}"
+                )
+            self.tasks = []  # Initialize with empty list for any ToolError
 
         except Exception as e:
             # Catch any other unexpected errors during loading/parsing
-            logger.error(f"Unexpected error while loading checklist {self.checklist_path}: {e}")
-            self.tasks = [] # Initialize with empty list for safety
-
+            logger.error(
+                f"Unexpected error while loading checklist {self.checklist_path}: {e}"
+            )
+            self.tasks = []  # Initialize with empty list for safety
 
     async def _rewrite_checklist_file(self):
         """
         Rewrites the checklist file with the current tasks.
         """
-        logger.info(f"Rewriting checklist file at: {self.checklist_path} with {len(self.tasks)} tasks.")
+        logger.info(
+            f"Rewriting checklist file at: {self.checklist_path} with {len(self.tasks)} tasks."
+        )
         content_to_write = []
         for task in self.tasks:
-            content_to_write.append(f"- [{task['status']}] {task['description']}")
+            agent_part = f" [Agente: {task['agent']}]" if task.get("agent") else ""
+            content_to_write.append(
+                f"- [{task['status']}]" + agent_part + f" {task['description']}"
+            )
 
         try:
-            await self.file_operator.write_file(str(self.checklist_path), "\n".join(content_to_write) + "\n")
+            await self.file_operator.write_file(
+                str(self.checklist_path), "\n".join(content_to_write) + "\n"
+            )
             # Success log is now part of the calling logger.info line
         except ToolError as e:
             logger.error(f"Error writing checklist file {self.checklist_path}: {e}")
         except Exception as e:
-            logger.error(f"Unexpected error writing checklist file {self.checklist_path}: {e}")
-
+            logger.error(
+                f"Unexpected error writing checklist file {self.checklist_path}: {e}"
+            )
 
     def get_tasks(self) -> List[Dict[str, str]]:
         """
@@ -118,13 +148,19 @@ class ChecklistManager:
         """
         return [task.copy() for task in self.tasks]
 
-    async def add_task(self, task_description: str, status: str = "Pendente") -> bool:
+    async def add_task(
+        self,
+        task_description: str,
+        status: str = "Pendente",
+        assigned_agent: Optional[str] = None,
+    ) -> bool:
         """
         Adds a new task to the checklist.
 
         Args:
             task_description: The description of the task.
             status: The initial status of the task (default: "Pendente").
+            assigned_agent: Optional name of the agent responsible for this task.
 
         Returns:
             True if the task was added, False if a task with the same description already exists.
@@ -135,7 +171,11 @@ class ChecklistManager:
             logger.warning(f"Task '{task_desc_stripped}' already exists. Not adding.")
             return False
 
-        new_task = {'description': task_desc_stripped, 'status': status}
+        new_task = {
+            "description": task_desc_stripped,
+            "status": status,
+            "agent": assigned_agent,
+        }
         self.tasks.append(new_task)
         logger.info(f"Adding task: '{task_desc_stripped}' with status '{status}'")
         await self._rewrite_checklist_file()
@@ -154,19 +194,52 @@ class ChecklistManager:
         """
         normalized_description_to_find = self._normalize_description(task_description)
         for task in self.tasks:
-            if self._normalize_description(task['description']) == normalized_description_to_find:
-                if task['status'] == new_status:
-                    logger.info(f"Task '{task_description.strip()}' already has status '{new_status}'. No update needed.")
+            if (
+                self._normalize_description(task["description"])
+                == normalized_description_to_find
+            ):
+                if task["status"] == new_status:
+                    logger.info(
+                        f"Task '{task_description.strip()}' already has status '{new_status}'. No update needed."
+                    )
                     return True
-                task['status'] = new_status
-                logger.info(f"Updating task status: '{normalized_description_to_find}' to '{new_status}'")
+                task["status"] = new_status
+                logger.info(
+                    f"Updating task status: '{normalized_description_to_find}' to '{new_status}'"
+                )
                 await self._rewrite_checklist_file()
                 return True
 
         logger.warning(f"Task not found for update: '{normalized_description_to_find}'")
         return False
 
-    def get_task_by_description(self, task_description: str) -> Optional[Dict[str, str]]:
+    async def update_task_agent(self, task_description: str, new_agent: str) -> bool:
+        """Updates the assigned agent for an existing task."""
+        normalized_description_to_find = self._normalize_description(task_description)
+        for task in self.tasks:
+            if (
+                self._normalize_description(task["description"])
+                == normalized_description_to_find
+            ):
+                if task.get("agent") == new_agent:
+                    logger.info(
+                        f"Task '{task_description.strip()}' already assigned to '{new_agent}'. No update needed."
+                    )
+                    return True
+                task["agent"] = new_agent
+                logger.info(
+                    f"Updating task agent: '{normalized_description_to_find}' to '{new_agent}'"
+                )
+                await self._rewrite_checklist_file()
+                return True
+        logger.warning(
+            f"Task not found for agent update: '{normalized_description_to_find}'"
+        )
+        return False
+
+    def get_task_by_description(
+        self, task_description: str
+    ) -> Optional[Dict[str, str]]:
         """
         Finds a task by its description (case-insensitive, whitespace-normalized).
 
@@ -178,8 +251,11 @@ class ChecklistManager:
         """
         normalized_description_to_find = self._normalize_description(task_description)
         for task in self.tasks:
-            if self._normalize_description(task['description']) == normalized_description_to_find:
-                return task.copy() # Return a copy
+            if (
+                self._normalize_description(task["description"])
+                == normalized_description_to_find
+            ):
+                return task.copy()  # Return a copy
         return None
 
     def is_task_complete(self, task_description: str) -> bool:
@@ -194,7 +270,7 @@ class ChecklistManager:
         """
         task = self.get_task_by_description(task_description)
         if task:
-            return task['status'] == "Concluído"
+            return task["status"] == "Concluído"
         return False
 
     def are_all_tasks_complete(self) -> bool:
@@ -206,16 +282,25 @@ class ChecklistManager:
             False if any task is not "Concluído".
         """
         if not self.tasks:
-            logger.info("are_all_tasks_complete: No tasks in checklist, returning False.")
-            return False # No tasks means not complete
+            logger.info(
+                "are_all_tasks_complete: No tasks in checklist, returning False."
+            )
+            return False  # No tasks means not complete
         for task in self.tasks:
-            if task.get('status', '').lower() != 'concluído': # Use .lower() for case-insensitivity
-                logger.info(f"are_all_tasks_complete: Task '{task.get('description')}' is not 'Concluído'. Status: '{task.get('status')}'. Returning False.")
+            if (
+                task.get("status", "").lower() != "concluído"
+            ):  # Use .lower() for case-insensitivity
+                logger.info(
+                    f"are_all_tasks_complete: Task '{task.get('description')}' is not 'Concluído'. Status: '{task.get('status')}'. Returning False."
+                )
                 return False
-        logger.info("are_all_tasks_complete: All tasks are 'Concluído', returning True.")
+        logger.info(
+            "are_all_tasks_complete: All tasks are 'Concluído', returning True."
+        )
         return True
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     # Example Usage (for testing purposes)
     # Ensure workspace_root is set correctly in your config for this to run standalone
     # from app.config import Config # Assuming Config class can set workspace_root
@@ -229,42 +314,54 @@ if __name__ == '__main__':
     if manager.checklist_path.exists():
         manager.checklist_path.unlink()
         logger.info(f"Removed old test_checklist.md for fresh test.")
-        manager = ChecklistManager(checklist_filename="test_checklist.md") # Re-init with no file
+        manager = ChecklistManager(
+            checklist_filename="test_checklist.md"
+        )  # Re-init with no file
 
     print(f"Initial tasks: {manager.get_tasks()}")
 
     manager.add_task("  Tarefa Inicial 1  ")
     manager.add_task("Tarefa Inicial 2", status="Em Andamento")
     manager.add_task("Tarefa já existente para teste de duplicidade")
-    manager.add_task("Tarefa já existente para teste de duplicidade") # Try adding duplicate
+    manager.add_task(
+        "Tarefa já existente para teste de duplicidade"
+    )  # Try adding duplicate
 
     print(f"Tasks after additions: {manager.get_tasks()}")
 
     manager.update_task_status("Tarefa Inicial 1", "Concluído")
-    manager.update_task_status("tarefa inicial 2  ", "Concluído") # Test normalization
+    manager.update_task_status("tarefa inicial 2  ", "Concluído")  # Test normalization
     manager.update_task_status("Tarefa Inexistente", "Concluído")
 
     print(f"Tasks after updates: {manager.get_tasks()}")
-    print(f"Is 'Tarefa Inicial 1' complete? {manager.is_task_complete('Tarefa Inicial 1')}")
+    print(
+        f"Is 'Tarefa Inicial 1' complete? {manager.is_task_complete('Tarefa Inicial 1')}"
+    )
     print(f"Are all tasks complete? {manager.are_all_tasks_complete()}")
 
     manager.add_task("Tarefa Pendente Final", "Pendente")
-    print(f"Are all tasks complete (after adding a pending one)? {manager.are_all_tasks_complete()}")
+    print(
+        f"Are all tasks complete (after adding a pending one)? {manager.are_all_tasks_complete()}"
+    )
 
     # Test loading from existing file
     print("\n--- Testing loading from existing file ---")
     manager_reloaded = ChecklistManager(checklist_filename="test_checklist.md")
     print(f"Tasks reloaded: {manager_reloaded.get_tasks()}")
     manager_reloaded.update_task_status("Tarefa Pendente Final", "Concluído")
-    print(f"Are all tasks complete (reloaded manager)? {manager_reloaded.are_all_tasks_complete()}")
+    print(
+        f"Are all tasks complete (reloaded manager)? {manager_reloaded.are_all_tasks_complete()}"
+    )
 
     # Test empty file scenario
     print("\n--- Testing empty file scenario ---")
     empty_manager = ChecklistManager(checklist_filename="empty_test_checklist.md")
     if empty_manager.checklist_path.exists():
         empty_manager.checklist_path.unlink()
-    empty_manager.file_operator.write_file(str(empty_manager.checklist_path), "") # create empty file
-    empty_manager._load_checklist() # force reload
+    empty_manager.file_operator.write_file(
+        str(empty_manager.checklist_path), ""
+    )  # create empty file
+    empty_manager._load_checklist()  # force reload
     print(f"Tasks from empty file: {empty_manager.get_tasks()}")
     print(f"All complete from empty: {empty_manager.are_all_tasks_complete()}")
 
@@ -273,9 +370,11 @@ if __name__ == '__main__':
     non_existent_manager = ChecklistManager(checklist_filename="non_existent_test.md")
     if non_existent_manager.checklist_path.exists():
         non_existent_manager.checklist_path.unlink()
-    non_existent_manager._load_checklist() # force reload after ensuring it's gone
+    non_existent_manager._load_checklist()  # force reload after ensuring it's gone
     print(f"Tasks from non-existent file: {non_existent_manager.get_tasks()}")
-    print(f"All complete from non-existent: {non_existent_manager.are_all_tasks_complete()}")
+    print(
+        f"All complete from non-existent: {non_existent_manager.are_all_tasks_complete()}"
+    )
 
     logger.info("ChecklistManager example finished.")
     # For cleanup, you might want to delete test_checklist.md

--- a/app/tool/checklist_tools.py
+++ b/app/tool/checklist_tools.py
@@ -1,32 +1,38 @@
-from typing import List, Dict, Any
+from typing import Any, Dict, Optional
 
-from app.tool.base import BaseTool, ToolResult
 from app.agent.checklist_manager import ChecklistManager
 from app.exceptions import ToolError
 from app.logger import logger
+from app.tool.base import BaseTool, ToolResult
+
 
 class ViewChecklistTool(BaseTool):
     name: str = "view_checklist"
-    description: str = "Displays all tasks and their current statuses from the main checklist."
-    args_schema: Dict[str, Any] = {
-        "type": "object",
-        "properties": {},
-        "required": []
-    }
+    description: str = "Displays all tasks, their current statuses and assigned agents from the main checklist."
+    args_schema: Dict[str, Any] = {"type": "object", "properties": {}, "required": []}
 
     async def execute(self, **kwargs: Any) -> ToolResult:
         logger.info("ViewChecklistTool invoked.")
         try:
             manager = ChecklistManager()
-            await manager._load_checklist() # Load tasks explicitly
+            await manager._load_checklist()  # Load tasks explicitly
             tasks = manager.get_tasks()
 
             if not tasks:
-                return ToolResult(output="O checklist está vazio ou não foi encontrado.")
+                return ToolResult(
+                    output="O checklist está vazio ou não foi encontrado."
+                )
 
             formatted_tasks = ["Checklist Principal de Tarefas:"]
             for task in tasks:
-                formatted_tasks.append(f"- [{task.get('status', 'N/A')}] {task.get('description', 'Sem descrição')}")
+                agent_display = (
+                    f" [Agente: {task.get('agent')}]" if task.get("agent") else ""
+                )
+                formatted_tasks.append(
+                    f"- [{task.get('status', 'N/A')}]"
+                    + agent_display
+                    + f" {task.get('description', 'Sem descrição')}"
+                )
 
             return ToolResult(output="\n".join(formatted_tasks))
         except Exception as e:
@@ -36,47 +42,75 @@ class ViewChecklistTool(BaseTool):
 
 class AddChecklistTaskTool(BaseTool):
     name: str = "add_checklist_task"
-    description: str = "Adds a new task to the main checklist. Default status is 'Pendente'."
+    description: str = (
+        "Adds a new task to the main checklist. Default status is 'Pendente'. "
+        "Optionally specify the agent responsible for the task."
+    )
     args_schema: Dict[str, Any] = {
         "type": "object",
         "properties": {
             "task_description": {
                 "type": "string",
-                "description": "The description of the task to add."
+                "description": "The description of the task to add.",
             },
             "status": {
                 "type": "string",
                 "description": "Optional. The initial status of the task (e.g., Pendente, Em Andamento). Defaults to 'Pendente'.",
                 "default": "Pendente",
-                "enum": ["Pendente", "Em Andamento", "Concluído", "Bloqueado"]
-            }
+                "enum": ["Pendente", "Em Andamento", "Concluído", "Bloqueado"],
+            },
+            "assigned_agent": {
+                "type": "string",
+                "description": "Optional. Name of the agent assigned to this task.",
+            },
         },
-        "required": ["task_description"]
+        "required": ["task_description"],
     }
 
-    async def execute(self, task_description: str, status: str = "Pendente", **kwargs: Any) -> ToolResult:
-        logger.info(f"AddChecklistTaskTool invoked with task_description: '{task_description}', status: '{status}'")
+    async def execute(
+        self,
+        task_description: str,
+        status: str = "Pendente",
+        assigned_agent: Optional[str] = None,
+        **kwargs: Any,
+    ) -> ToolResult:
+        logger.info(
+            f"AddChecklistTaskTool invoked with task_description: '{task_description}', status: '{status}', assigned_agent: '{assigned_agent}'"
+        )
         try:
             # Validate status against allowed values (although schema should handle this, good for defense)
             allowed_statuses = self.args_schema["properties"]["status"]["enum"]
             if status not in allowed_statuses:
-                raise ToolError(f"Status inválido '{status}'. Status permitidos são: {', '.join(allowed_statuses)}")
+                raise ToolError(
+                    f"Status inválido '{status}'. Status permitidos são: {', '.join(allowed_statuses)}"
+                )
 
             manager = ChecklistManager()
-            await manager._load_checklist() # Load tasks explicitly
-            success = await manager.add_task(task_description=task_description, status=status)
+            await manager._load_checklist()  # Load tasks explicitly
+            success = await manager.add_task(
+                task_description=task_description,
+                status=status,
+                assigned_agent=assigned_agent,
+            )
 
             if success:
-                return ToolResult(output=f"Tarefa '{task_description}' adicionada ao checklist com status '{status}'.")
+                msg = f"Tarefa '{task_description}' adicionada ao checklist com status '{status}'."
+                if assigned_agent:
+                    msg += f" Agente designado: {assigned_agent}."
+                return ToolResult(output=msg)
             else:
                 # Check if task exists to provide a more specific message
                 existing_task = manager.get_task_by_description(task_description)
                 if existing_task:
-                    return ToolResult(output=f"Falha ao adicionar tarefa '{task_description}'. Tarefa já existe com status '{existing_task['status']}'.")
-                return ToolResult(output=f"Falha ao adicionar tarefa '{task_description}'. Consulte os logs para mais detalhes.")
+                    return ToolResult(
+                        output=f"Falha ao adicionar tarefa '{task_description}'. Tarefa já existe com status '{existing_task['status']}'."
+                    )
+                return ToolResult(
+                    output=f"Falha ao adicionar tarefa '{task_description}'. Consulte os logs para mais detalhes."
+                )
         except ToolError as te:
             logger.error(f"AddChecklistTaskTool: ToolError adding task: {te}")
-            raise te # Re-raise ToolError
+            raise te  # Re-raise ToolError
         except Exception as e:
             logger.error(f"AddChecklistTaskTool: Unexpected error adding task: {e}")
             raise ToolError(f"Erro inesperado ao adicionar tarefa ao checklist: {e}")
@@ -84,55 +118,96 @@ class AddChecklistTaskTool(BaseTool):
 
 class UpdateChecklistTaskTool(BaseTool):
     name: str = "update_checklist_task"
-    description: str = "Updates the status of an existing task in the main checklist."
+    description: str = (
+        "Updates the status of an existing task in the main checklist. "
+        "You may also reassign the task to a different agent."
+    )
     args_schema: Dict[str, Any] = {
         "type": "object",
         "properties": {
             "task_description": {
                 "type": "string",
-                "description": "The description of the task to update. Must match an existing task."
+                "description": "The description of the task to update. Must match an existing task.",
             },
             "new_status": {
                 "type": "string",
                 "description": "The new status for the task (e.g., Pendente, Em Andamento, Concluído, Bloqueado).",
-                "enum": ["Pendente", "Em Andamento", "Concluído", "Bloqueado"]
-            }
+                "enum": ["Pendente", "Em Andamento", "Concluído", "Bloqueado"],
+            },
+            "new_agent": {
+                "type": "string",
+                "description": "Optional new agent responsible for the task.",
+            },
         },
-        "required": ["task_description", "new_status"]
+        "required": ["task_description", "new_status"],
     }
 
-    async def execute(self, task_description: str, new_status: str, **kwargs: Any) -> ToolResult:
-        logger.info(f"UpdateChecklistTaskTool invoked with task_description: '{task_description}', new_status: '{new_status}'")
+    async def execute(
+        self,
+        task_description: str,
+        new_status: str,
+        new_agent: Optional[str] = None,
+        **kwargs: Any,
+    ) -> ToolResult:
+        logger.info(
+            f"UpdateChecklistTaskTool invoked with task_description: '{task_description}', new_status: '{new_status}', new_agent: '{new_agent}'"
+        )
 
         # Validate new_status against allowed values (although schema should handle this, good for defense)
         allowed_statuses = self.args_schema["properties"]["new_status"]["enum"]
         if new_status not in allowed_statuses:
-            logger.warning(f"UpdateChecklistTaskTool: Invalid new_status provided: '{new_status}'")
-            raise ToolError(f"Status inválido '{new_status}'. Status permitidos são: {', '.join(allowed_statuses)}")
+            logger.warning(
+                f"UpdateChecklistTaskTool: Invalid new_status provided: '{new_status}'"
+            )
+            raise ToolError(
+                f"Status inválido '{new_status}'. Status permitidos são: {', '.join(allowed_statuses)}"
+            )
 
         try:
             manager = ChecklistManager()
-            await manager._load_checklist() # Load tasks explicitly
+            await manager._load_checklist()  # Load tasks explicitly
 
             # Check if task exists before attempting update for a clearer message
             # get_task_by_description is synchronous as it operates on already loaded tasks
             task_to_update = manager.get_task_by_description(task_description)
             if not task_to_update:
-                return ToolResult(output=f"Falha ao atualizar status da tarefa '{task_description}'. Tarefa não encontrada.")
+                return ToolResult(
+                    output=f"Falha ao atualizar status da tarefa '{task_description}'. Tarefa não encontrada."
+                )
 
-            if task_to_update['status'] == new_status:
-                 return ToolResult(output=f"Tarefa '{task_description}' já está com o status '{new_status}'. Nenhuma alteração realizada.")
+            if task_to_update["status"] == new_status:
+                return ToolResult(
+                    output=f"Tarefa '{task_description}' já está com o status '{new_status}'. Nenhuma alteração realizada."
+                )
 
-            success = await manager.update_task_status(task_description=task_description, new_status=new_status)
+            success = await manager.update_task_status(
+                task_description=task_description,
+                new_status=new_status,
+            )
+
+            if success and new_agent:
+                await manager.update_task_agent(
+                    task_description=task_description,
+                    new_agent=new_agent,
+                )
 
             if success:
-                return ToolResult(output=f"Status da tarefa '{task_description}' atualizado para '{new_status}'.")
+                msg = f"Status da tarefa '{task_description}' atualizado para '{new_status}'."
+                if new_agent:
+                    msg += f" Agente designado: {new_agent}."
+                return ToolResult(output=msg)
             else:
                 # This else might be redundant if the above checks (not found, already same status) are comprehensive
-                return ToolResult(output=f"Falha ao atualizar status da tarefa '{task_description}'. Verifique se a tarefa existe e o novo status é diferente do atual.")
+                return ToolResult(
+                    output=f"Falha ao atualizar status da tarefa '{task_description}'. Verifique se a tarefa existe e o novo status é diferente do atual."
+                )
         except ToolError as te:
             logger.error(f"UpdateChecklistTaskTool: ToolError updating task: {te}")
-            raise te # Re-raise ToolError
+            raise te  # Re-raise ToolError
         except Exception as e:
-            logger.error(f"UpdateChecklistTaskTool: Unexpected error updating task: {e}")
-            raise ToolError(f"Erro inesperado ao atualizar status da tarefa no checklist: {e}")
+            logger.error(
+                f"UpdateChecklistTaskTool: Unexpected error updating task: {e}"
+            )
+            raise ToolError(
+                f"Erro inesperado ao atualizar status da tarefa no checklist: {e}"
+            )

--- a/tests/test_checklist_manager.py
+++ b/tests/test_checklist_manager.py
@@ -1,0 +1,42 @@
+import pytest
+
+from app.agent.checklist_manager import ChecklistManager
+from app.tool.checklist_tools import (
+    AddChecklistTaskTool,
+    UpdateChecklistTaskTool,
+    ViewChecklistTool,
+)
+
+
+@pytest.mark.asyncio
+async def test_add_and_view_task_with_agent(tmp_path):
+    from app import config as app_config
+
+    app_config.WORKSPACE_ROOT = tmp_path
+    manager = ChecklistManager()
+    add_tool = AddChecklistTaskTool()
+    await add_tool.execute(task_description="Task A", assigned_agent="Agent1")
+    await manager._load_checklist()
+    tasks = manager.get_tasks()
+    assert tasks == [{"description": "Task A", "status": "Pendente", "agent": "Agent1"}]
+    view_tool = ViewChecklistTool()
+    result = await view_tool.execute()
+    assert "Agent1" in result.output
+
+
+@pytest.mark.asyncio
+async def test_update_task_agent(tmp_path):
+    from app import config as app_config
+
+    app_config.WORKSPACE_ROOT = tmp_path
+    manager = ChecklistManager()
+    add_tool = AddChecklistTaskTool()
+    await add_tool.execute(task_description="Task B", assigned_agent="Agent1")
+    updater = UpdateChecklistTaskTool()
+    await updater.execute(
+        task_description="Task B", new_status="Em Andamento", new_agent="Agent2"
+    )
+    await manager._load_checklist()
+    task = manager.get_task_by_description("Task B")
+    assert task["status"] == "Em andamento"
+    assert task["agent"] == "Agent2"


### PR DESCRIPTION
## Summary
- support designated agents in `ChecklistManager`
- update checklist tools to handle agent parameter
- add tests for new checklist behaviour

## Testing
- `pre-commit run --files tests/test_checklist_manager.py app/agent/checklist_manager.py app/tool/checklist_tools.py`
- `PYTHONPATH=. pytest tests/test_checklist_manager.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6851d1102c3c8324840db3451c713a3d