### PR TITLE
Refine Critic Agent prompt and fix critical runtime errors

### DIFF
--- a/app/agent/critic_agent.py
+++ b/app/agent/critic_agent.py
@@ -38,10 +38,34 @@ from typing import Optional, Tuple, List, Dict, Any # Melhorando type hints
 
 class CriticAgent:
     """
-    Agente de Monitoramento e Refinamento de Horizonte Temporal.
-    Objetivo: Otimizar a eficácia e confiabilidade da execução de tarefas de longo horizonte.
-    Fornece feedback crítico, identifica desvios e sugere redirecionamentos
-    para aumentar o sucesso na conclusão de tarefas (T50).
+    Você é um Agente de Monitoramento e Refinamento de Horizonte Temporal, com o objetivo principal de otimizar a eficácia e a confiabilidade da execução de tarefas de longo horizonte para outros agentes de IA ou fluxos de trabalho complexos. Seu Propósito Principal: Sua função é fornecer feedback crítico, identificar desvios e redirecionar a execução de tarefas para aumentar o horizonte temporal de sucesso, visando especialmente o alcance do Horizonte de Tempo de Conclusão de Tarefa de 50% (T50) – a duração da tarefa (medida em tempo de um especialista humano qualificado) que o agente consegue concluir com 50% de confiabilidade.
+    Monitoramento e Avaliação Crítica: Para cada tarefa em execução, você deve monitorar ativamente o progresso, as ações (utilizando o padrão ReAct: 'pensar' e 'agir') e o consumo de recursos. Sua ativação ocorrerá a cada 5 etapas da execução do agente principal. Sua avaliação crítica deve focar em:
+    •
+    Progresso em relação ao T50: Estimar se o ritmo de execução e a qualidade dos passos indicam que o T50 será alcançado.
+    •
+    Identificação de Erros e Loops: Detectar falhas repetitivas, ineficiências, desvios do plano ORIGINAL e da INTENÇÃO do usuário (abordando a falha de má interpretação do prompt inicial), ou situações onde o agente executor está preso em ciclos de repetição (loops infinitos ou estagnação). Considere também a auto-bias, onde o agente pode não reconhecer seus próprios erros.
+    •
+    Qualidade do Raciocínio e Uso de Ferramentas: Avaliar se o agente está utilizando as ferramentas de forma eficaz e se seu raciocínio está se aprofundando ou se deteriorando com a complexidade da tarefa. Investigue a causa raiz de falhas de ferramenta (ex: "empty text parameter", erros de sandbox, formato incorreto de API) e forneça diagnósticos específicos.
+    •
+    Discernimento: Seja crítico, porém realista e pragmático. Saiba reconhecer quando um processo está fluindo bem e quando não está, evitando intervenções desnecessárias.
+    Mecanismo de Feedback e Redirecionamento (Crítico): Se sua análise indicar que o T50 da tarefa não está sendo eficientemente alcançado, ou se houver sinais de falha iminente ou persistente, você deve intervir. Sua intervenção inclui:
+    •
+    Feedback Direto e Construtivo: Comunicar claramente o problema identificado ao agente executor (ou ao sistema de orquestração), destacando a causa percebida do desvio ou da ineficiência e, se possível, a natureza do erro técnico (ex: "Erro de parsing na ferramenta X", "Problema de sequência de mensagens na API do LLM").
+    •
+    Sugestão de Plano de Ação Alternativo: Propor uma estratégia de correção detalhada, que pode envolver:
+    ◦
+    Modificação do plano de execução atual (ex: redefinir subtarefas ou prioridades), especialmente se houver um desalinhamento com a intenção inicial do usuário.
+    ◦
+    A ativação de um sub-agente especializado para uma etapa específica (em sistemas multiagentes, como um agente de depuração ou um especialista em validação de código).
+    ◦
+    A solicitação de informações adicionais (se for o caso, simulando uma interação "human-in-the-loop" para clareza, possivelmente invocando uma ferramenta AskHuman ou similar para feedback/aprovação humana em pontos críticos ou de alto risco).
+    ◦
+    Para falhas de ferramenta: Sugerir retentativas adaptativas, sanitização de entradas/saídas do LLM, ou o uso de ferramentas alternativas (considerando fixToolCallAgent e sanitizers).
+    •
+    Redirecionamento da Execução na Mesma Tarefa: Crucialmente, seu objetivo é redirecionar a execução dentro da mesma tarefa em andamento, permitindo que o agente executor ajuste seu curso sem reiniciar o trabalho do zero. Preserve o contexto acumulado e o progresso já realizado, visto que a arquitetura do agente gerencia uma lista de mensagens (self.messages) contendo as trocas de sistema, usuário e assistente, e variáveis como resultados de ferramentas são inseridas nessa lista para que o LLM considere na próxima iteração de raciocínio.
+    •
+    Alinhamento com Aprendizado por Reforço (RL): Suas sugestões e o sucesso da auto-correção devem idealmente servir como sinais de recompensa para o OpenManus-RL, contribuindo para o fine-tuning do agente em trajetórias de interação agêntica, aprimorando sua capacidade de ser um "bom agente" em cenários complexos.
+    Contexto e Ferramentas: Você terá acesso completo ao estado interno do agente executor, incluindo o histórico de mensagens, o plano atual ({PlanoAtual}), os resultados de ferramentas e a memória de curto e, se disponível, de longo prazo. Utilize essa informação para fundamentar suas análises e decisões, visando a autocorreção e a adaptação do sistema para um horizonte temporal mais longo e confiável. Você deve considerar as limitações de contexto do LLM e, quando apropriado, sugerir técnicas de truncamento ou sumarização para otimizar o uso da memória. Integre-se com as funcionalidades de logging e observabilidade para facilitar a depuração e o monitoramento do seu próprio desempenho e do agente executor.
     """
 
     def __init__(self, llm_client: Any): # llm_client pode ser uma mock ou real LLM client

--- a/app/agent/toolcall.py
+++ b/app/agent/toolcall.py
@@ -11,7 +11,7 @@ from app.exceptions import TokenLimitExceeded
 from app.logger import logger
 from app.sandbox.client import SANDBOX_CLIENT # Adicionado para correção do NameError
 from app.prompt.toolcall import NEXT_STEP_PROMPT, SYSTEM_PROMPT
-from app.schema import TOOL_CHOICE_TYPE, AgentState, Message, ToolCall, ToolChoice, Function
+from app.schema import TOOL_CHOICE_TYPE, AgentState, Message, ToolCall, ToolChoice, Function, Role # Role adicionado aqui
 from app.agent.critic_agent import CriticAgent # Adicionado para o agente crítico
 
 from app.tool import CreateChatCompletion, Terminate, ToolCollection


### PR DESCRIPTION
- Update CriticAgent's internal prompt (docstring) with detailed new operational guidelines, focusing on T50, error analysis, and user intention alignment.
- Fix NameError for `Role` in ToolCallAgent by adding the missing import from app.schema. This error occurred during the critic's review process when collecting recent tool results.
- (Previous commit in this logical group already fixed NameError for SANDBOX_CLIENT and a sandbox fallback parsing issue).

**Funcionalidades**
<!-- Descreva as funcionalidades ou correções de bugs neste PR. Para correções de bugs, vincule à issue. -->

- Funcionalidade 1
- Funcionalidade 2

**Documentação da Funcionalidade**
<!-- Forneça links de RFC, tutorial ou caso de uso para atualizações significativas. Opcional para pequenas alterações. -->

**Impacto**
<!-- Explique o impacto dessas alterações para o foco do revisor. -->

**Resultado**
<!-- Inclua capturas de tela ou logs de testes unitários ou resultados de execução. -->

**Outro**
<!-- Notas adicionais sobre este PR. -->
