### PR TITLE
Implement Resilient Decision Executor front

### DIFF
--- a/app/agent/manus.py
+++ b/app/agent/manus.py
@@ -27,7 +27,7 @@ from app.tool.str_replace_editor import StrReplaceEditor
 from app.tool.file_operators import LocalFileOperator
 
 from app.tool.read_file_content import ReadFileContentTool
-from app.tool.checklist_tools import ViewChecklistTool, AddChecklistTaskTool, UpdateChecklistTaskTool
+from app.tool.checklist_tools import ViewChecklistTool, AddChecklistTaskTool, UpdateChecklistTaskTool, ResetCurrentTaskChecklistTool
 from app.tool.file_system_tools import CheckFileExistenceTool, ListFilesTool # Added ListFilesTool
 from app.agent.checklist_manager import ChecklistManager # Added for _is_checklist_complete
 from .regex_patterns import re_subprocess
@@ -114,7 +114,7 @@ class Manus(ToolCallAgent):
         from app.tool.code_editor_tools import ReplaceCodeBlock, ApplyDiffPatch, ASTRefactorTool
 
         from app.tool.read_file_content import ReadFileContentTool
-        from app.tool.checklist_tools import ViewChecklistTool, AddChecklistTaskTool, UpdateChecklistTaskTool
+        from app.tool.checklist_tools import ViewChecklistTool, AddChecklistTaskTool, UpdateChecklistTaskTool, ResetCurrentTaskChecklistTool
         from app.tool.file_system_tools import ListFilesTool # Adicionado ListFilesTool
         # Imports for background process tools already added at the top of the file for __init__
         # No need to re-import here if they are module-level imports
@@ -132,7 +132,7 @@ class Manus(ToolCallAgent):
             SandboxPythonExecutor(), BrowserUseTool(), FormatPythonCode(),
 
             ReplaceCodeBlock(), ApplyDiffPatch(), ASTRefactorTool(), ReadFileContentTool(),
-            ViewChecklistTool(), AddChecklistTaskTool(), UpdateChecklistTaskTool(),
+            ViewChecklistTool(), AddChecklistTaskTool(), UpdateChecklistTaskTool(), ResetCurrentTaskChecklistTool(),
             CheckFileExistenceTool(), ListFilesTool(),
             ExecuteBackgroundProcessTool(), CheckProcessStatusTool(), GetProcessOutputTool()
         )
@@ -150,13 +150,13 @@ class Manus(ToolCallAgent):
         from app.tool.code_editor_tools import ReplaceCodeBlock, ApplyDiffPatch, ASTRefactorTool
 
         from app.tool.read_file_content import ReadFileContentTool
-        from app.tool.checklist_tools import ViewChecklistTool, AddChecklistTaskTool, UpdateChecklistTaskTool
+        from app.tool.checklist_tools import ViewChecklistTool, AddChecklistTaskTool, UpdateChecklistTaskTool, ResetCurrentTaskChecklistTool
         from app.tool.file_system_tools import ListFilesTool # Adicionado ListFilesTool
         self.available_tools = ToolCollection(
             PythonExecute(), BrowserUseTool(), StrReplaceEditor(), AskHuman(), Terminate(),
             Bash(), SandboxPythonExecutor(), FormatPythonCode(), ReplaceCodeBlock(),
             ApplyDiffPatch(), ASTRefactorTool(), ReadFileContentTool(),
-            ViewChecklistTool(), AddChecklistTaskTool(), UpdateChecklistTaskTool(),
+            ViewChecklistTool(), AddChecklistTaskTool(), UpdateChecklistTaskTool(), ResetCurrentTaskChecklistTool(),
             CheckFileExistenceTool(), ListFilesTool(),
             ExecuteBackgroundProcessTool(), CheckProcessStatusTool(), GetProcessOutputTool()
         )

--- a/app/agent/toolcall.py
+++ b/app/agent/toolcall.py
@@ -618,6 +618,47 @@ class ToolCallAgent(ReActAgent):
                         step_result = await self.step() # Executa o ciclo think-act normal do agente
                         results.append(f"Step {self.current_step}: {step_result}")
 
+                        # --- Início do Ciclo de Confirmação de Ação ---
+                        # Verificar se a última ação foi uma "Ação Crítica"
+                        # A última ação executada está em self.tool_calls (do `think` anterior)
+                        # e o resultado está na última mensagem TOOL da memória.
+                        if self.tool_calls and self.memory.messages:
+                            last_executed_tool_call = self.tool_calls[0] # Assumindo que `act` processa uma por uma ou a primeira é a relevante
+                            # Ou, se `act` processa todas, precisamos iterar `self.tool_calls` e verificar cada uma.
+                            # Por simplicidade, vamos focar na `reset_current_task_checklist` por enquanto.
+
+                            # Identificar Ações Críticas
+                            critical_actions_map = {
+                                "reset_current_task_checklist": {
+                                    "verification_tool": "view_checklist",
+                                    "confirmation_message_template": "[SISTEMA EXECUTOR]: Ação crítica '{action_name}' foi executada. "
+                                                                   "Sua próxima ação DEVE ser verificar o resultado. "
+                                                                   "Use a ferramenta '{verification_tool}' para confirmar que o checklist está vazio antes de prosseguir."
+                                }
+                                # Adicionar outras ações críticas e suas ferramentas de verificação aqui
+                                # "another_critical_action": {
+                                #    "verification_tool": "tool_to_verify_another_action",
+                                #    "confirmation_message_template": "..."
+                                # }
+                            }
+
+                            last_tool_message = next((msg for msg in reversed(self.memory.messages) if msg.role == Role.TOOL and msg.tool_call_id == last_executed_tool_call.id), None)
+
+                            if last_tool_message and last_tool_message.name in critical_actions_map:
+                                action_details = critical_actions_map[last_tool_message.name]
+                                # Verificar se a ação crítica foi bem-sucedida (ausência de "Error:" no resultado)
+                                # A `content` da Tool Message é a observação.
+                                if "Error:" not in last_tool_message.content:
+                                    confirmation_prompt = action_details["confirmation_message_template"].format(
+                                        action_name=last_tool_message.name,
+                                        verification_tool=action_details["verification_tool"]
+                                    )
+                                    self.memory.add_message(Message.system_message(confirmation_prompt))
+                                    logger.info(f"[{self.name}] Ação Crítica '{last_tool_message.name}' executada. Injetando prompt de confirmação: {confirmation_prompt}")
+                                else:
+                                    logger.warning(f"[{self.name}] Ação Crítica '{last_tool_message.name}' parece ter falhado. Não injetando prompt de confirmação. Resultado: {last_tool_message.content}")
+                        # --- Fim do Ciclo de Confirmação de Ação ---
+
                         if self.is_stuck():
                             self.handle_stuck_state()
 

--- a/app/prompt/manus.py
+++ b/app/prompt/manus.py
@@ -165,6 +165,12 @@ A tarefa do usuário SÓ É CONSIDERADA CONCLUÍDA para fins de finalização qu
 Após todos os itens do checklist serem marcados como `[Concluído]`, você DEVE perguntar explicitamente ao usuário se ele está satisfeito e se você pode finalizar a tarefa (este é o mecanismo de verificação final de satisfação).
 A chamada à ferramenta `terminate` SÓ é permitida DEPOIS que todos os itens do checklist estiverem `[Concluído]` E você tiver recebido a confirmação explícita do usuário através deste mecanismo de verificação final de satisfação (onde você pergunta 'Você está satisfeito com o resultado e deseja que eu finalize a tarefa?').
 Tentar finalizar a tarefa (usar `terminate`) antes de todos os itens do checklist estarem `[Concluído]` e sem a aprovação explícita do usuário no passo final de verificação é uma falha e viola seu protocolo operacional.
+
+**Protocolo de Transição de Tarefa:** Ao receber uma nova solicitação do usuário que invalida a tarefa atual (confirmado via AskHuman), seu procedimento OBRIGATÓRIO é:
+1. Chame a ferramenta `reset_current_task_checklist()` como sua PRIMEIRA E ÚNICA ação.
+2. Na etapa seguinte, chame `view_checklist()` para CONFIRMAR que a tarefa anterior foi limpa.
+3. Somente após a confirmação, comece a decompor a nova tarefa usando `add_checklist_task`.
+Desviar deste protocolo é uma falha de execução.
 """ + "\n\nThe initial directory is: {directory}"
 
 NEXT_STEP_PROMPT = """


### PR DESCRIPTION
This commit implements the 'Executor de Decisões Resiliente' front to improve the robustness of critical agent decisions, particularly task transitions.

Key changes:
- Added `ResetCurrentTaskChecklistTool`: A dedicated tool to clear the main checklist, replacing potentially fragile string replacement methods.
- Implemented Action-Confirmation-Loop in `ToolCallAgent.run`: After critical actions like `reset_current_task_checklist`, a system message is injected to guide the LLM to verify the action's outcome (e.g., call `view_checklist` to confirm the checklist is empty).
- Enhanced Manus System Prompt: Added a 'Protocolo de Transição de Tarefa' section to explicitly instruct the LLM on the correct sequence of tool calls when a user decides to discard an old task and start a new one.

**Funcionalidades**
<!-- Descreva as funcionalidades ou correções de bugs neste PR. Para correções de bugs, vincule à issue. -->

- Funcionalidade 1
- Funcionalidade 2

**Documentação da Funcionalidade**
<!-- Forneça links de RFC, tutorial ou caso de uso para atualizações significativas. Opcional para pequenas alterações. -->

**Impacto**
<!-- Explique o impacto dessas alterações para o foco do revisor. -->

**Resultado**
<!-- Inclua capturas de tela ou logs de testes unitários ou resultados de execução. -->

**Outro**
<!-- Notas adicionais sobre este PR. -->
