### PR TITLE
Fix: Correct SyntaxError in Manus sandbox fallback logic

### DIFF
--- a/app/agent/manus.py
+++ b/app/agent/manus.py
@@ -940,10 +940,10 @@ Agora, forneça sua análise e a sugestão de ferramenta e parâmetros no format
                 original_failed_tool_call = self._pending_fallback_tool_call # self._pending_fallback_tool_call é garantido não ser None aqui
 
                 if user_response_text == "sim":
-                    logger.info(f"Usuário aprovou fallback para PythonExecute para a tool_call original ID: {original_failed_tool_call.id}")
-                try:
-                    original_args = json.loads(original_failed_tool_call.function.arguments)
-                    fallback_args = {}
+                    logger.info(f"Usuário aprovou fallback para PythonExecute para a tool_call original ID: {original_failed_tool_call.id}") # Esta linha já está dentro do `if user_response_text == "sim":`
+                    try:
+                        original_args = json.loads(original_failed_tool_call.function.arguments)
+                        fallback_args = {}
 
                     if "code" in original_args and original_args["code"]:
                         fallback_args["code"] = original_args["code"]


### PR DESCRIPTION
Moved a logging statement within the try-except block in the `think` method to resolve a SyntaxError caused by improper indentation impacting the if/elif/else structure for handling user responses to sandbox execution fallback.

**Funcionalidades**
<!-- Descreva as funcionalidades ou correções de bugs neste PR. Para correções de bugs, vincule à issue. -->

- Funcionalidade 1
- Funcionalidade 2

**Documentação da Funcionalidade**
<!-- Forneça links de RFC, tutorial ou caso de uso para atualizações significativas. Opcional para pequenas alterações. -->

**Impacto**
<!-- Explique o impacto dessas alterações para o foco do revisor. -->

**Resultado**
<!-- Inclua capturas de tela ou logs de testes unitários ou resultados de execução. -->

**Outro**
<!-- Notas adicionais sobre este PR. -->
