### PR TITLE
Fix: Improve checklist reset and task update robustness

### DIFF
--- a/test_reset_tool.py
+++ b/test_reset_tool.py
@@ -1,0 +1,29 @@
+import asyncio
+from app.tool.checklist_tools import ResetCurrentTaskChecklistTool
+from app.config import config
+import os
+
+async def main():
+    # Ensure workspace exists (though it should from previous steps)
+    os.makedirs(config.workspace_root, exist_ok=True)
+
+    tool = ResetCurrentTaskChecklistTool()
+    print(f"Executing ResetCurrentTaskChecklistTool...")
+    result = await tool.execute()
+    print(f"Tool execution result: {result.output if result else 'No result'}")
+
+    # Verify file content
+    checklist_path = config.workspace_root / "checklist_principal_tarefa.md"
+    if os.path.exists(checklist_path):
+        with open(checklist_path, 'r') as f:
+            content = f.read()
+            print(f"Content of checklist_principal_tarefa.md after reset:\n'''{content}'''")
+            if content == "":
+                print("Test Passed: Checklist file is empty after reset.")
+            else:
+                print("Test Failed: Checklist file is NOT empty after reset.")
+    else:
+        print("Test Failed: Checklist file does not exist after reset.")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/test_sre_create_overwrite.py
+++ b/test_sre_create_overwrite.py
@@ -1,0 +1,41 @@
+import asyncio
+from app.tool.str_replace_editor import StrReplaceEditor
+from app.config import config
+import os
+
+async def main():
+    # Ensure workspace exists
+    os.makedirs(config.workspace_root, exist_ok=True)
+
+    tool = StrReplaceEditor()
+    checklist_content = """- [Pendente] [Agente: TestAgent] Minha Tarefa De Teste Com Tag De Agente
+- [Pendente] Outra Tarefa Sem Tag De Agente"""
+    checklist_path = str(config.workspace_root / "checklist_principal_tarefa.md")
+
+    print(f"Attempting to create/overwrite checklist file at: {checklist_path}")
+    # Use the 'create' command with overwrite=True
+    # The StrReplaceEditor's execute method expects keyword arguments matching its parameters.
+    # The 'create' command uses 'path' and 'file_text'. 'overwrite' is also a parameter.
+    result = await tool.execute(
+        command="create",
+        path=checklist_path,
+        file_text=checklist_content,
+        overwrite=True # Explicitly overwrite
+    )
+    print(f"Tool execution result: {result.output if result and result.output else result.error if result else 'No result'}")
+
+    # Verify file content
+    if os.path.exists(checklist_path):
+        with open(checklist_path, 'r') as f:
+            content = f.read().strip() # Use strip to remove potential trailing newline for comparison
+            expected_content_stripped = checklist_content.strip()
+            print(f"Content of checklist_principal_tarefa.md after SRE create/overwrite:\n'''{content}'''")
+            if content == expected_content_stripped:
+                print("Test Passed: Checklist file content is as expected after SRE create/overwrite.")
+            else:
+                print(f"Test Failed: Checklist file content mismatch.\nExpected:\n'''{expected_content_stripped}'''\nGot:\n'''{content}'''")
+    else:
+        print("Test Failed: Checklist file does not exist after SRE create/overwrite.")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/test_update_task_tool.py
+++ b/test_update_task_tool.py
@@ -1,0 +1,62 @@
+import asyncio
+from app.tool.checklist_tools import UpdateChecklistTaskTool, ViewChecklistTool
+from app.config import config
+import os
+
+async def main():
+    os.makedirs(config.workspace_root, exist_ok=True)
+
+    update_tool = UpdateChecklistTaskTool()
+    view_tool = ViewChecklistTool()
+
+    task_to_update_variations = [
+        "Minha Tarefa De Teste Com Tag De Agente", # Exact description LLM might use (without agent tag)
+        " minha tarefa de teste com tag de agente ", # With spaces and different case
+        "[Agente: TestAgent] Minha Tarefa De Teste Com Tag De Agente" # With agent tag (less likely from LLM but good to test)
+    ]
+    new_status = "Em Andamento"
+
+    print("Initial checklist state:")
+    initial_view_result = await view_tool.execute()
+    print(initial_view_result.output if initial_view_result else "Could not view checklist")
+    print("-" * 30)
+
+    for i, desc_variation in enumerate(task_to_update_variations):
+        print(f"Attempting to update task using description variation {i+1}: '{desc_variation}' to status '{new_status}'")
+        result = await update_tool.execute(task_description=desc_variation, new_status=new_status)
+        print(f"Update Result {i+1}: {result.output if result and result.output else result.error if result else 'No result'}")
+
+        print(f"Checklist state after attempt {i+1}:")
+        current_view_result = await view_tool.execute()
+        print(current_view_result.output if current_view_result else "Could not view checklist")
+        print("-" * 30)
+
+        # Check if the specific task was updated
+        # This requires parsing the view_tool output or using ChecklistManager directly
+        # For simplicity in this script, we'll rely on the tool's output message for success indication.
+        if result and result.output and "atualizado para" in result.output:
+            print(f"Test Variation {i+1} Passed: Task update reported success.")
+            # Reset for next variation test if needed, or break if one success is enough
+            # For this test, we want to see if it *can* be updated. If it's updated once, subsequent variations
+            # might report "already has status" if we don't change new_status.
+            # Let's change the status for the next attempt to ensure we're testing the match, not just "already set".
+            new_status = "Concluído" if new_status == "Em Andamento" else "Em Andamento"
+        elif result and result.error:
+             print(f"Test Variation {i+1} Failed: Task update reported error: {result.error}")
+        elif result and "Tarefa não encontrada" in result.output:
+             print(f"Test Variation {i+1} Failed: Task update reported 'Tarefa não encontrada'.")
+        else:
+            print(f"Test Variation {i+1} Ambiguous: Tool output: {result.output if result else 'No result'}")
+
+
+    # Test updating the second task as a control
+    print("Attempting to update 'Outra Tarefa Sem Tag De Agente' to 'Concluído'")
+    control_result = await update_tool.execute(task_description="Outra Tarefa Sem Tag De Agente", new_status="Concluído")
+    print(f"Control Update Result: {control_result.output if control_result and control_result.output else control_result.error if control_result else 'No result'}")
+    print(f"Final checklist state:")
+    final_view_result = await view_tool.execute()
+    print(final_view_result.output if final_view_result else "Could not view checklist")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
This commit addresses several issues related to checklist management:

1. Implemented automatic checklist reset in `Manus.think()` when a new task is initiated, ensuring a clean state.
2. Corrected `ResetCurrentTaskChecklistTool` to properly empty the checklist file by leveraging the new `ChecklistManager.reset_checklist()` method.
3. Enhanced `ChecklistManager._normalize_description()` to remove agent tags (e.g., '[Agente: TestAgent]') before comparison. This makes `update_checklist_task` more robust in matching task descriptions, resolving 'Tarefa não encontrada' errors caused by variations in descriptions provided by the LLM.
4. Ensured `ChecklistManager._load_checklist()` correctly handles an empty checklist file without logging parsing errors for non-task lines like headers.

**Funcionalidades**
<!-- Descreva as funcionalidades ou correções de bugs neste PR. Para correções de bugs, vincule à issue. -->

- Funcionalidade 1
- Funcionalidade 2

**Documentação da Funcionalidade**
<!-- Forneça links de RFC, tutorial ou caso de uso para atualizações significativas. Opcional para pequenas alterações. -->

**Impacto**
<!-- Explique o impacto dessas alterações para o foco do revisor. -->

**Resultado**
<!-- Inclua capturas de tela ou logs de testes unitários ou resultados de execução. -->

**Outro**
<!-- Notas adicionais sobre este PR. -->
