### PR TITLE
Fix: Enhance checklist management and agent improvisation

### DIFF
--- a/app/agent/checklist_manager.py
+++ b/app/agent/checklist_manager.py
@@ -85,8 +85,11 @@ class ChecklistManager:
                         "agent": agent.strip() if agent else None,
                     }
                     self.tasks.append(task_entry)
+                elif line.startswith("#"):
+                    # Silently ignore lines starting with # (comments/headers)
+                    pass
                 else:
-                    # Log lines that don't match the expected format
+                    # Log other lines that don't match the expected format and are not comments
                     logger.warning(
                         f"Could not parse checklist line: '{line}' in file {self.checklist_path} at line {line_number + 1}. Skipping."
                     )

--- a/app/agent/manus.py
+++ b/app/agent/manus.py
@@ -756,9 +756,13 @@ Agora, forneça sua análise e a sugestão de ferramenta e parâmetros no format
                     ]
                     # Adicionar uma mensagem ao assistente para que o LLM saiba que o reset ocorreu/está ocorrendo.
                     # E também para que o usuário veja esta ação.
-                    self.memory.add_message(Message.assistant_message(
-                        content="Detectada uma nova tarefa. Resetando o checklist da tarefa anterior para começar do zero.",
-                        tool_calls=self.tool_calls
+                    # Corrigido: Usar Message.from_tool_calls ou criar e atribuir.
+                    # Como o self.tool_calls já está definido com a chamada para reset_current_task_checklist,
+                    # e a mensagem é um pensamento do assistente que leva a essa chamada,
+                    # Message.from_tool_calls é o mais apropriado.
+                    self.memory.add_message(Message.from_tool_calls(
+                        tool_calls=self.tool_calls,
+                        content="Detectada uma nova tarefa. Resetando o checklist da tarefa anterior para começar do zero."
                     ))
                     # Força a execução desta ferramenta de reset e depois o LLM pensará novamente.
                     return True # Indica que uma ação (reset) foi planejada e deve ser executada.

--- a/run_improvisation_think_test.py
+++ b/run_improvisation_think_test.py
@@ -1,0 +1,116 @@
+import asyncio
+import os
+import json
+
+from app.agent.manus import Manus
+from app.schema import Message, Role, Function as FunctionCall, ToolCall
+from app.tool.checklist_tools import AddChecklistTaskTool, UpdateChecklistTaskTool, ViewChecklistTool, ResetCurrentTaskChecklistTool
+from app.config import config
+from app.logger import logger
+
+async def run_think_on_improv_state():
+    logger.info("Re-setting up agent state for improvisation 'think' test...")
+    agent = await Manus.create()
+    agent.current_step = 5 # Simulate a few steps have passed (same as setup script)
+
+    # 1. Initial User Prompt
+    agent.memory.add_message(Message.user_message("crie dados sinteticos que depois podem ser usados pra simular machine learning com aleatoriedade... gere uma boa amostra de dados"))
+
+    # Simulate initial checklist reset and decomposition by LLM
+    reset_tool = ResetCurrentTaskChecklistTool()
+    await reset_tool.execute()
+
+    add_tool = AddChecklistTaskTool()
+    task1_desc = "Definir os requisitos e características dos dados sintéticos a serem gerados para simulação de machine learning."
+    task2_desc = "Implementar a geração de dados sintéticos com aleatoriedade em Python, atendendo aos requisitos definidos."
+    task3_desc = "Testar a geração dos dados sintéticos e validar a amostra gerada."
+
+    await add_tool.execute(task_description=task1_desc)
+    await add_tool.execute(task_description=task2_desc)
+    await add_tool.execute(task_description=task3_desc)
+
+    agent.memory.add_message(Message.assistant_message(content=f"Vou começar definindo os requisitos para a tarefa: '{task1_desc}'."))
+
+    update_tool = UpdateChecklistTaskTool()
+    await update_tool.execute(task_description=task1_desc, new_status="Em Andamento")
+
+    # 2. Agent asks for parameters (AskHuman)
+    ask_human_question = (
+        "Para prosseguir com a geração dos dados sintéticos para simulação de machine learning, preciso que você me informe os requisitos básicos:\n\n"
+        "1. Tipo de problema de machine learning (ex: classificação binária, multi-classe, regressão, clustering).\n"
+        "2. Quantidade aproximada de amostras (linhas).\n"
+        "3. Quantidade e tipos de variáveis (numéricas, categóricas, booleanas etc.).\n"
+        "4. Deseja correlação entre variáveis?\n"
+        "5. Características especiais (ruído, outliers, desbalanceamento, etc.).\n"
+        "6. Deseja variável alvo (target) para treino supervisionado?\n\n"
+        "Por favor, forneça essas informações para que eu possa criar um perfil adequado para os dados sintéticos."
+    )
+    ask_human_tool_call_id = "ask_human_for_params_123"
+    # Use from_tool_calls to correctly create the message
+    agent.memory.add_message(
+        Message.from_tool_calls(
+            tool_calls=[
+                ToolCall(id=ask_human_tool_call_id, function=FunctionCall(name="AskHuman", arguments=json.dumps({"inquire": ask_human_question})))
+            ],
+            content="Preciso de mais detalhes para definir os requisitos dos dados."
+        )
+    )
+    # Simulate AskHuman tool result in memory
+    agent.memory.add_message(
+        Message(role=Role.TOOL, name="AskHuman", tool_call_id=ask_human_tool_call_id, content=ask_human_question)
+    )
+
+    # 3. User responds with "tanto faz..."
+    user_improvisation_response = "tanto fas tudo isso, capriche e improvite, o que eu quero saber mesmo é o T50"
+    agent.memory.add_message(Message.user_message(user_improvisation_response))
+
+    # 4. Agent marks task1 as Bloqueado (as per original log, to set the stage for the new `think` call)
+    await update_tool.execute(task_description=task1_desc, new_status="Bloqueado")
+    agent.memory.add_message(Message.assistant_message(content=f"Tarefa '{task1_desc}' marcada como Bloqueado devido à falta de especificações claras."))
+
+    logger.info("Agent state re-established. Calling agent.think() now...")
+
+    # CRUCIAL STEP: Call think()
+    await agent.think()
+
+    logger.info("agent.think() executed. Analyzing results...")
+    logger.info("Final agent memory:")
+    for i, msg in enumerate(agent.memory.messages):
+        content_summary = str(msg.content)[:200] + "..." if msg.content and len(str(msg.content)) > 200 else str(msg.content)
+        tc_summary = ""
+        if msg.tool_calls:
+            tc_names = [tc.function.name for tc in msg.tool_calls]
+            tc_summary = f", Planned TCs: {tc_names}"
+        logger.info(f"  Msg {i}: Role={msg.role}, Content='{content_summary}'{tc_summary}")
+
+    if agent.tool_calls:
+        logger.info(f"Agent planned tool_calls: {[tc.function.name for tc in agent.tool_calls]}")
+        if "AskHuman" in [tc.function.name for tc in agent.tool_calls]:
+            logger.error("Test Failed: Agent is still planning to AskHuman for parameters.")
+        else:
+            logger.info("Test Observation: Agent did NOT plan AskHuman. This is good.")
+            # Further checks could be if it planned to update checklist or generate code.
+    else:
+        logger.info("Test Observation: Agent did not plan any tool calls in this step.")
+        # Check the last assistant message for explanation
+        last_assistant_msg = next((m for m in reversed(agent.memory.messages) if m.role == Role.ASSISTANT), None)
+        if last_assistant_msg and last_assistant_msg.content:
+            logger.info(f"Last assistant thought: {last_assistant_msg.content}")
+            if "parâmetros padrão" in last_assistant_msg.content.lower() or "vou assumir" in last_assistant_msg.content.lower():
+                logger.info("Test Passed: Agent mentioned using default/assumed parameters.")
+            else:
+                logger.warning("Test Observation: Agent did not explicitly mention default parameters in its last thought, but did not ask again.")
+        else:
+            logger.error("Test Failed: Agent did not plan tools and left no clear explanation.")
+
+
+    logger.info("Final checklist state after think call:")
+    view_tool = ViewChecklistTool()
+    final_checklist_view = await view_tool.execute()
+    logger.info(final_checklist_view.output if final_checklist_view else "Could not view final checklist")
+
+    await agent.cleanup()
+    logger.info("Improvisation 'think' test finished.")
+
+if __name__ == "__main__":
+    asyncio.run(run_think_on_improv_state())

--- a/setup_improvisation_test_state.py
+++ b/setup_improvisation_test_state.py
@@ -1,0 +1,108 @@
+import asyncio
+import os
+import json
+
+from app.agent.manus import Manus
+from app.schema import Message, Role, Function as FunctionCall, ToolCall # Corrected import
+from app.tool.checklist_tools import AddChecklistTaskTool, UpdateChecklistTaskTool, ViewChecklistTool, ResetCurrentTaskChecklistTool
+from app.config import config
+from app.logger import logger
+
+async def setup_agent_for_improvisation_test():
+    logger.info("Setting up agent state for improvisation test...")
+    agent = await Manus.create()
+    agent.current_step = 5 # Simulate a few steps have passed
+
+    # 1. Initial User Prompt
+    agent.memory.add_message(Message.user_message("crie dados sinteticos que depois podem ser usados pra simular machine learning com aleatoriedade... gere uma boa amostra de dados"))
+
+    # Simulate initial checklist reset and decomposition by LLM
+    # (as per the new automatic reset logic, checklist should be empty initially)
+    # Then LLM adds initial tasks.
+
+    # Simulate reset_current_task_checklist call and its effect (empty checklist)
+    # In a real run, Manus.think() would call this. Here we manually ensure state.
+    reset_tool = ResetCurrentTaskChecklistTool()
+    await reset_tool.execute()
+    logger.info("Simulated: Checklist reset.")
+
+    # Simulate LLM adding initial tasks
+    add_tool = AddChecklistTaskTool()
+    task1_desc = "Definir os requisitos e características dos dados sintéticos a serem gerados para simulação de machine learning."
+    task2_desc = "Implementar a geração de dados sintéticos com aleatoriedade em Python, atendendo aos requisitos definidos."
+    task3_desc = "Testar a geração dos dados sintéticos e validar a amostra gerada."
+
+    await add_tool.execute(task_description=task1_desc)
+    await add_tool.execute(task_description=task2_desc)
+    await add_tool.execute(task_description=task3_desc)
+    logger.info("Simulated: Initial tasks added to checklist by LLM.")
+
+    # Simulate agent deciding to ask for parameters for task1
+    agent.memory.add_message(Message.assistant_message(content=f"Vou começar definindo os requisitos para a tarefa: '{task1_desc}'."))
+
+    # Simulate agent marking task1 as 'Em Andamento'
+    update_tool = UpdateChecklistTaskTool()
+    await update_tool.execute(task_description=task1_desc, new_status="Em Andamento")
+    logger.info(f"Simulated: Task '{task1_desc}' marked as 'Em Andamento'.")
+
+    # 2. Agent asks for parameters (AskHuman)
+    ask_human_question = (
+        "Para prosseguir com a geração dos dados sintéticos para simulação de machine learning, preciso que você me informe os requisitos básicos:\n\n"
+        "1. Tipo de problema de machine learning (ex: classificação binária, multi-classe, regressão, clustering).\n"
+        "2. Quantidade aproximada de amostras (linhas).\n"
+        "3. Quantidade e tipos de variáveis (numéricas, categóricas, booleanas etc.).\n"
+        "4. Deseja correlação entre variáveis?\n"
+        "5. Características especiais (ruído, outliers, desbalanceamento, etc.).\n"
+        "6. Deseja variável alvo (target) para treino supervisionado?\n\n"
+        "Por favor, forneça essas informações para que eu possa criar um perfil adequado para os dados sintéticos."
+    )
+    ask_human_tool_call_id = "ask_human_for_params_123"
+    agent.memory.add_message(
+        Message.from_tool_calls(
+            tool_calls=[
+                ToolCall(id=ask_human_tool_call_id, function=FunctionCall(name="AskHuman", arguments=json.dumps({"inquire": ask_human_question})))
+            ],
+            content="Preciso de mais detalhes para definir os requisitos dos dados."
+        )
+    )
+    logger.info("Simulated: Agent planned AskHuman for data parameters.")
+
+    # Simulate AskHuman tool result
+    agent.memory.add_message(
+        Message(role=Role.TOOL, name="AskHuman", tool_call_id=ask_human_tool_call_id, content=ask_human_question) # The tool echoes the question in its result for context
+    )
+
+    # 3. User responds with "tanto faz..."
+    user_improvisation_response = "tanto fas tudo isso, capriche e improvite, o que eu quero saber mesmo é o T50"
+    agent.memory.add_message(Message.user_message(user_improvisation_response))
+    logger.info(f"Simulated: User response: '{user_improvisation_response}'")
+
+    # 4. Agent marks task1 as Bloqueado (as seen in logs)
+    # This happened in the log because the agent didn't know how to proceed with "tanto faz"
+    # Our new prompt should prevent this, but we set it to reflect the state *before* the new prompt takes effect.
+    await update_tool.execute(task_description=task1_desc, new_status="Bloqueado")
+    agent.memory.add_message(Message.assistant_message(content=f"Tarefa '{task1_desc}' marcada como Bloqueado devido à falta de especificações claras."))
+    logger.info(f"Simulated: Task '{task1_desc}' marked as 'Bloqueado'.")
+
+    logger.info("Agent state setup complete. Current memory:")
+    for i, msg in enumerate(agent.memory.messages):
+        content_summary = str(msg.content)[:100] + "..." if msg.content and len(str(msg.content)) > 100 else str(msg.content)
+        tc_summary = f", TC: {len(msg.tool_calls)}" if msg.tool_calls else ""
+        logger.info(f"  Msg {i}: Role={msg.role}, Content='{content_summary}'{tc_summary}")
+
+    # Save agent state to a file to be loaded by the next script
+    # For simplicity, we'll just re-run this setup if needed, or pass agent instance if possible.
+    # For this test, the next step will re-instantiate and replay messages.
+    # This script's main purpose is to verify the setup and messages.
+
+    # View final checklist state
+    logger.info("Final checklist state after setup:")
+    view_tool = ViewChecklistTool()
+    final_checklist_view = await view_tool.execute()
+    logger.info(final_checklist_view.output if final_checklist_view else "Could not view final checklist")
+
+    await agent.cleanup() # Clean up agent resources like browser if they were implicitly started by tools.
+    logger.info("Setup script finished.")
+
+if __name__ == "__main__":
+    asyncio.run(setup_agent_for_improvisation_test())

--- a/test_automatic_reset.py
+++ b/test_automatic_reset.py
@@ -1,0 +1,104 @@
+import asyncio
+import os
+import json # For FunctionCall arguments
+
+from app.agent.manus import Manus
+from app.schema import Message, Role, Function as FunctionCall, ToolCall # Corrected import
+from app.tool.checklist_tools import ResetCurrentTaskChecklistTool, ViewChecklistTool
+from app.agent.checklist_manager import ChecklistManager # To verify parsing
+from app.config import config
+from app.logger import logger # For capturing logs if needed
+
+async def main():
+    logger.info("Starting Test 1: Automatic Checklist Reset & Parsing")
+
+    # Ensure workspace and initial checklist file exist (as setup by previous step)
+    initial_checklist_path_str = str(config.workspace_root / "checklist_principal_tarefa.md")
+    if not os.path.exists(initial_checklist_path_str):
+        logger.error("TEST PRECONDITION FAILED: Initial checklist_principal_tarefa.md does not exist.")
+        return
+
+    with open(initial_checklist_path_str, 'r') as f:
+        logger.info(f"Initial checklist content:\n{f.read()}")
+
+    # 1. Instantiate Manus and give it a new prompt
+    # Assuming Manus.create() and other setup is lightweight enough for this test script
+    agent = await Manus.create()
+    agent.memory.add_message(Message.user_message("Este é um prompt para uma tarefa completamente nova."))
+
+    # agent.current_step will be 0 initially.
+    # The ToolCallAgent.run() method increments current_step to 1 *before* the first call to self.step() (which calls think).
+    # So, to simulate the state where manus.think() is called for the first time for a new task:
+    agent.current_step = 1
+
+    logger.info("Calling agent.think() for the first time with a new prompt...")
+    await agent.think()
+
+    # 2. Check if the first planned tool call is reset_current_task_checklist
+    if not agent.tool_calls:
+        logger.error("Test Failed: Agent did not plan any tool calls.")
+        print_agent_memory(agent)
+        return
+
+    first_tool_call = agent.tool_calls[0]
+    expected_tool_name = ResetCurrentTaskChecklistTool().name
+
+    if first_tool_call.function.name == expected_tool_name:
+        logger.info(f"Test Passed (Step 2a): Agent correctly planned '{expected_tool_name}' as the first action.")
+
+        # 3. Simulate execution of reset_current_task_checklist
+        logger.info(f"Simulating execution of '{expected_tool_name}'...")
+        reset_tool = ResetCurrentTaskChecklistTool()
+        reset_result = await reset_tool.execute()
+        logger.info(f"Result of {expected_tool_name}: {reset_result.output if reset_result else 'No output'}")
+
+        # Check if checklist file is now empty
+        if os.path.exists(initial_checklist_path_str):
+            with open(initial_checklist_path_str, 'r') as f:
+                content_after_reset = f.read()
+                if content_after_reset == "":
+                    logger.info("Test Passed (Step 2b): Checklist file is empty after reset.")
+                else:
+                    logger.error(f"Test Failed (Step 2b): Checklist file is NOT empty. Content:\n'''{content_after_reset}'''")
+        else:
+            logger.error("Test Failed (Step 2b): Checklist file does not exist after reset (it should be empty).")
+
+        # 4. Simulate view_checklist and check parsing
+        # The agent's next step (after the reset tool call is processed by the main loop) would be to think again.
+        # The prompt for Manus instructs it to call view_checklist after a reset.
+        # We can simulate this part by directly using ChecklistManager.
+        logger.info("Simulating ChecklistManager loading the (now empty) checklist...")
+        checklist_manager = ChecklistManager()
+        # Capture logs during _load_checklist to check for parsing warnings
+        # This is a bit hacky for a test script, but serves the purpose.
+        # A more robust way would be to use a custom log handler if this were a formal test suite.
+
+        # Temporarily redirect logger to capture warnings (if possible, or check manually)
+        # For this test, we'll rely on observing the logs printed by the script run.
+        await checklist_manager._load_checklist()
+        if not checklist_manager.tasks:
+            logger.info("Test Passed (Step 2c): ChecklistManager loaded an empty task list.")
+            # Check logs manually for "Could not parse checklist line" for the header if it was written.
+            # Since reset_checklist writes an empty file, no header should be there, so no warning.
+        else:
+            logger.error(f"Test Failed (Step 2c): ChecklistManager loaded tasks: {checklist_manager.tasks}")
+
+    else:
+        logger.error(f"Test Failed (Step 2a): Expected first tool to be '{expected_tool_name}', but got '{first_tool_call.function.name}'.")
+        print_agent_memory(agent)
+
+    # Clean up agent
+    await agent.cleanup()
+    logger.info("Test 1 finished.")
+
+def print_agent_memory(agent: Manus):
+    logger.info("Current agent memory:")
+    for i, msg in enumerate(agent.memory.messages):
+        logger.info(f"Msg {i}: Role={msg.role}, Content='{str(msg.content)[:200]}...', ToolCalls={len(msg.tool_calls) if msg.tool_calls else 0}")
+        if msg.tool_calls:
+            for tc_idx, tc in enumerate(msg.tool_calls):
+                logger.info(f"  ToolCall {tc_idx}: ID={tc.id}, Name={tc.function.name}, Args='{str(tc.function.arguments)[:100]}...'")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/test_sre_set_initial_checklist.py
+++ b/test_sre_set_initial_checklist.py
@@ -1,0 +1,38 @@
+import asyncio
+from app.tool.str_replace_editor import StrReplaceEditor
+from app.config import config
+import os
+
+async def main():
+    os.makedirs(config.workspace_root, exist_ok=True)
+
+    tool = StrReplaceEditor()
+    checklist_content = """# Checklist Antigo
+- [Concluído] Tarefa Velha 1
+- [Pendente] Tarefa Velha 2 que não foi feita"""
+    checklist_path = str(config.workspace_root / "checklist_principal_tarefa.md")
+
+    print(f"Attempting to set initial checklist content at: {checklist_path}")
+    result = await tool.execute(
+        command="create", # Create implies overwrite if file_text is provided and overwrite=True
+        path=checklist_path,
+        file_text=checklist_content,
+        overwrite=True
+    )
+    print(f"Tool execution result: {result.output if result and result.output else result.error if result else 'No result'}")
+
+    # Verify file content
+    if os.path.exists(checklist_path):
+        with open(checklist_path, 'r') as f:
+            content = f.read().strip()
+            expected_content_stripped = checklist_content.strip()
+            print(f"Content of checklist_principal_tarefa.md:\n'''{content}'''")
+            if content == expected_content_stripped:
+                print("Test Setup Succeeded: Checklist file content is as expected.")
+            else:
+                print(f"Test Setup Failed: Checklist file content mismatch.")
+    else:
+        print("Test Setup Failed: Checklist file does not exist.")
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
This commit addresses issues identified from user feedback and logs related to checklist handling and agent behavior with vague prompts:

1.  Corrected `Message.assistant_message()` usage in `Manus.think()` for automatic checklist reset. It now correctly uses `Message.from_tool_calls()` to prevent TypeErrors.
2.  Improved `ChecklistManager._load_checklist()` to silently ignore header/comment lines (starting with '#'), making checklist parsing more robust and reducing log noise.
3.  Ensured `ResetCurrentTaskChecklistTool` uses the `ChecklistManager.reset_checklist()` method, which now correctly writes an empty file for a reset checklist.
4.  Refined `ChecklistManager._normalize_description()` to strip agent tags, improving the reliability of `update_checklist_task`.
5.  Updated the system prompt in `app/prompt/manus.py` to:
    *   Guide the LLM to prefer using `reset_current_task_checklist` over manual file editing for new tasks.
    *   Provide the agent with a default strategy for handling vague data generation requests or when asked to improvise, aiming to prevent request loops.

**Funcionalidades**
<!-- Descreva as funcionalidades ou correções de bugs neste PR. Para correções de bugs, vincule à issue. -->

- Funcionalidade 1
- Funcionalidade 2

**Documentação da Funcionalidade**
<!-- Forneça links de RFC, tutorial ou caso de uso para atualizações significativas. Opcional para pequenas alterações. -->

**Impacto**
<!-- Explique o impacto dessas alterações para o foco do revisor. -->

**Resultado**
<!-- Inclua capturas de tela ou logs de testes unitários ou resultados de execução. -->

**Outro**
<!-- Notas adicionais sobre este PR. -->
