### PR TITLE
SRE Fase 1.X: Correções de Estabilidade e Lógica de Estado

### DIFF
--- a/app/tool/sandbox_python_executor.py
+++ b/app/tool/sandbox_python_executor.py
@@ -1,14 +1,14 @@
 import asyncio # Should be there
-import os # Added
-import uuid # Should be there
-from typing import Any, Dict, Optional # Optional should be there
+import os
+import uuid
+from typing import Any, Dict, Optional
 
 from app.sandbox.client import SANDBOX_CLIENT
 from app.config import config
 from app.sandbox.core.exceptions import SandboxTimeoutError
-from app.tool.base import BaseTool
+from app.tool.base import BaseTool, ToolResult # Import ToolResult
 from app.exceptions import ToolError
-from app.logger import logger # Added
+from app.logger import logger
 
 
 class SandboxPythonExecutor(BaseTool):


### PR DESCRIPTION
- Corrigido JSONDecodeError na lógica de fallback do SandboxPythonExecutor em Manus.think() ajustando como os resultados da ferramenta são formatados e parseados.
- Resolvido problema de duplo reset do checklist em Manus.think() com a introdução da flag `_reset_initiated_by_new_directive`.
- Padronizado o retorno de SandboxPythonExecutor para usar ToolResult, incluindo o tratamento de `pid_file_path` e erros de ambiente.
- Padronizado o retorno de PythonExecute para usar ToolResult.
- Aprimorada a lógica em ToolCallAgent.execute_tool para lidar consistentemente com ToolResult e formatação de observações como JSON quando a saída da ferramenta é um dicionário.

**Funcionalidades**
<!-- Descreva as funcionalidades ou correções de bugs neste PR. Para correções de bugs, vincule à issue. -->

- Funcionalidade 1
- Funcionalidade 2

**Documentação da Funcionalidade**
<!-- Forneça links de RFC, tutorial ou caso de uso para atualizações significativas. Opcional para pequenas alterações. -->

**Impacto**
<!-- Explique o impacto dessas alterações para o foco do revisor. -->

**Resultado**
<!-- Inclua capturas de tela ou logs de testes unitários ou resultados de execução. -->

**Outro**
<!-- Notas adicionais sobre este PR. -->
