### PR TITLE
SRE Hotfix: Reverte toolcall.py, Remove GUI, Mantém Correções Fase 1/1.X

### DIFF
--- a/app/agent/toolcall.py
+++ b/app/agent/toolcall.py
@@ -6,17 +6,16 @@ from pydantic import Field
 
 from app.config import config
 from app.agent.react import ReActAgent
-# from app.config import config # Already imported
-from app.exceptions import TokenLimitExceeded, AgentEnvironmentError
+from app.config import config # Added
+from app.exceptions import TokenLimitExceeded
 from app.logger import logger
-from app.sandbox.client import SANDBOX_CLIENT
+from app.sandbox.client import SANDBOX_CLIENT # Adicionado para correção do NameError
 from app.prompt.toolcall import NEXT_STEP_PROMPT, SYSTEM_PROMPT
-from app.schema import TOOL_CHOICE_TYPE, AgentState, Message, ToolCall, ToolChoice, Function, Role
-from app.agent.critic_agent import CriticAgent
-from app.core.environment_validator import EnvironmentValidator # Adicionado para validação de ambiente
+from app.schema import TOOL_CHOICE_TYPE, AgentState, Message, ToolCall, ToolChoice, Function, Role # Role adicionado aqui
+from app.agent.critic_agent import CriticAgent # Adicionado para o agente crítico
 
 from app.tool import CreateChatCompletion, Terminate, ToolCollection
-from app.tool.base import ToolResult
+from app.tool.base import ToolResult # Added
 from app.tool.file_operators import LocalFileOperator # Added
 from app.tool.code_formatter import FormatPythonCode # Added
 from app.tool.code_editor_tools import ReplaceCodeBlock, ApplyDiffPatch, ASTRefactorTool # Modified
@@ -334,31 +333,26 @@ class ToolCallAgent(ReActAgent):
             logger.info(f"[TOOL_END] Tool '{name}' executed successfully.")
 
             # Store PID file path if this was the sandbox executor
-            # Este bloco é executado ANTES da formatação da observação.
-            # tool_output aqui é o retorno direto do SandboxPythonExecutor.execute(), que agora é ToolResult.
             if name == SandboxPythonExecutor().name:
-                if isinstance(tool_output, ToolResult):
-                    if tool_output.error:
-                        # Se houve um erro primário na ferramenta (ex: falha ao copiar, erro de ambiente ANTES de executar)
-                        # pid_file_path pode não estar no output ou não ser relevante.
-                        logger.warning(f"SandboxPythonExecutor retornou um erro: {tool_output.error}. Não esperando pid_file_path.")
-                    elif isinstance(tool_output.output, dict) and "pid_file_path" in tool_output.output:
-                        self._current_sandbox_pid_file = tool_output.output["pid_file_path"]
-                        self._current_script_tool_call_id = command.id
-                        self._current_sandbox_pid = None # Reset PID, will be read if needed
-                        logger.info(f"Stored PID file path '{self._current_sandbox_pid_file}' for tool call ID '{command.id}'.")
-                    else:
-                        # O output não é um dict ou não tem pid_file_path, mas não houve erro primário na ToolResult.
-                        # Isso pode acontecer se o script executou mas não gerou o output esperado pela ferramenta interna,
-                        # ou se o sandbox_python_executor teve uma falha interna não capturada como ToolResult.error.
-                        logger.warning(
-                            f"Tool {name} (ToolResult) did not contain 'pid_file_path' in its 'output' dictionary "
-                            f"or 'output' was not a dictionary. Output: {tool_output.output}"
-                        )
+                # Check if tool_output is a dict, which is the expected return type for SandboxPythonExecutor
+                # when it successfully returns a pid_file_path.
+                if isinstance(tool_output, dict) and "pid_file_path" in tool_output:
+                    self._current_sandbox_pid_file = tool_output["pid_file_path"]
+                    self._current_script_tool_call_id = command.id
+                    self._current_sandbox_pid = None # Reset PID, will be read if needed
+                    logger.info(f"Stored PID file path '{self._current_sandbox_pid_file}' for tool call ID '{command.id}'.")
+                # If tool_output is ToolResult, it means SandboxPythonExecutor might have wrapped its dict output
+                # or an error occurred. If it's an error, it will be handled by the ToolResult processing below.
+                # If it's a ToolResult containing the dict, we might need to extract it.
+                # However, the current SandboxPythonExecutor().execute() method returns a dict directly, not a ToolResult.
+                # So, this condition might be more for future-proofing or if other tools behave differently.
+                elif isinstance(tool_output, ToolResult) and isinstance(tool_output.output, dict) and "pid_file_path" in tool_output.output:
+                    self._current_sandbox_pid_file = tool_output.output["pid_file_path"]
+                    self._current_script_tool_call_id = command.id
+                    self._current_sandbox_pid = None
+                    logger.info(f"Stored PID file path '{self._current_sandbox_pid_file}' (from ToolResult.output) for tool call ID '{command.id}'.")
                 else:
-                    # Isso não deveria acontecer se SandboxPythonExecutor sempre retorna ToolResult.
-                    logger.error(f"SandboxPythonExecutor retornou um tipo inesperado: {type(tool_output)}, esperava ToolResult.")
-
+                    logger.warning(f"Tool {name} did not return 'pid_file_path' as expected. Output type: {type(tool_output)}")
 
             # Handle special tools
             await self._handle_special_tool(name=name, result=tool_output)
@@ -368,17 +362,10 @@ class ToolCallAgent(ReActAgent):
                 if tool_output.base64_image:
                     self._current_base64_image = tool_output.base64_image
 
-                if tool_output.error: # Erro primário da ferramenta
+                if tool_output.error:
                     current_output_str = f"Error: {tool_output.error}"
-                    # Se houver output adicional mesmo com erro, podemos concatenar
-                    if tool_output.output is not None:
-                        current_output_str += f"\nAdditional output: {json.dumps(tool_output.output) if isinstance(tool_output.output, dict) else str(tool_output.output)}"
                 elif tool_output.output is not None:
-                    # Se output for dict, serializar para JSON para a observação.
-                    if isinstance(tool_output.output, dict):
-                        current_output_str = json.dumps(tool_output.output)
-                    else:
-                        current_output_str = str(tool_output.output)
+                    current_output_str = str(tool_output.output)
                 else:
                     current_output_str = "" # Saída vazia se não houver erro nem output
 
@@ -387,16 +374,6 @@ class ToolCallAgent(ReActAgent):
                     if current_output_str
                     else f"Cmd `{name}` completed with no observable output or error."
                 )
-                elif isinstance(tool_output, dict): # Tratar dict especificamente
-                    self._current_base64_image = None
-                    try:
-                        # Converter o dicionário para uma string JSON válida
-                        current_output_str = json.dumps(tool_output)
-                        observation = f"Observed output of cmd `{name}` executed (dict converted to JSON):\n{current_output_str}"
-                    except TypeError as e:
-                        logger.error(f"Falha ao serializar a saída do dicionário da ferramenta '{name}' para JSON: {e}. Usando str() como fallback.")
-                        current_output_str = str(tool_output) # Fallback para str() se json.dumps falhar
-                        observation = f"Observed output of cmd `{name}` executed (converted from {type(tool_output)} using str()):\n{current_output_str}"
             elif isinstance(tool_output, str):
                 self._current_base64_image = None # Garantir que não haja imagem base64 de uma execução anterior
                 current_output_str = tool_output
@@ -406,11 +383,11 @@ class ToolCallAgent(ReActAgent):
                     else f"Cmd `{name}` completed with no observable string output."
                 )
             else:
-                    # Caso para tipos inesperados que não são ToolResult, str ou dict
-                    logger.warning(f"Tool '{name}' returned an unhandled type: {type(tool_output)}. Converting to string using str().")
+                # Caso para tipos inesperados, pode ser logado ou tratado como erro
+                logger.warning(f"Tool '{name}' returned an unexpected type: {type(tool_output)}. Converting to string.")
                 self._current_base64_image = None
                 current_output_str = str(tool_output) # Tenta converter para string como fallback
-                    observation = f"Observed output of cmd `{name}` executed (converted from {type(tool_output)} using str()):\n{current_output_str}"
+                observation = f"Observed output of cmd `{name}` executed (converted from {type(tool_output)}):\n{current_output_str}"
 
             return observation
         except json.JSONDecodeError:

--- a/app/logger.py
+++ b/app/logger.py
@@ -2,46 +2,6 @@ import sys
 from datetime import datetime
 
 from loguru import logger as _logger
-
-# --- Import GUI log streaming components ---
-import asyncio # Moved asyncio import to top as it's used by DB logging too
-import sys # Ensure sys is imported
-from pathlib import Path
-# Assuming app/logger.py, so PROJECT_ROOT is parent.parent
-# Adjust if this assumption is wrong for the worker's execution context.
-PROJECT_ROOT_PATH = Path(__file__).resolve().parent.parent
-sys.path.insert(0, str(PROJECT_ROOT_PATH))
-
-try:
-    from gui.backend.log_streamer import get_log_queue, format_log_record
-except ImportError as e:
-    # This allows the rest of the application to function if the GUI part is missing,
-    # though logs won't go to the GUI queue.
-    print(f"INFO: GUI log streaming components not found or import error: {e}. GUI logging will be disabled.", file=sys.stderr) # Make sure to import sys for stderr
-    # Define dummy functions so logger setup doesn't crash
-    def get_log_queue(): return None
-    def format_log_record(record): return None # This was missing in my plan, but it is in the instructions
-    # Optionally, set a flag to avoid adding the sink if components are missing
-    _gui_logging_enabled = False
-else:
-    _gui_logging_enabled = True
-# --- End GUI log streaming components ---
-
-# --- Import GUI database components ---
-try:
-    from gui.backend.database import AsyncSessionLocal, LogEntry
-    # If log_streamer components are missing, database logging for GUI also doesn't make sense
-    if not _gui_logging_enabled: # Assuming _gui_logging_enabled is set by log_streamer import
-        raise ImportError("GUI logging disabled, so database logging for GUI is also disabled.")
-except ImportError as e:
-    print(f"INFO: GUI database components not found or import error: {e}. GUI database logging will be disabled.", file=sys.stderr)
-    _gui_db_logging_enabled = False
-    # Define dummy LogEntry if needed for the rest of the file not to break, though sink won't use it.
-    class LogEntry: pass 
-else:
-    _gui_db_logging_enabled = True
-# --- End GUI database components ---
-
 from app.config import PROJECT_ROOT
 
 
@@ -59,125 +19,16 @@ def define_log_level(print_level="INFO", logfile_level="DEBUG", name: str = None
         f"{name}_{formatted_date}" if name else formatted_date
     )  # name a log with prefix name
 
-    _logger.remove()
-    _logger.add(sys.stderr, level=print_level)
-    _logger.add(PROJECT_ROOT / f"logs/{log_name}.log", level=logfile_level)
+    _logger.remove() # Remove default handlers
+    _logger.add(sys.stderr, level=print_level) # Add console sink
+    _logger.add(PROJECT_ROOT / f"logs/{log_name}.log", level=logfile_level) # Add file sink
 
-    # --- Add GUI sink ---
-    if _gui_logging_enabled and get_log_queue() is not None:
-        log_queue_instance = get_log_queue() # Keep this if get_log_queue() is light and needed for check
-
-        def gui_sink(message):
-            # Acessar message.record uma única vez no início
-            try:
-                record_data = message.record # Keep the full record for flexibility
-                record_message_text = record_data["message"]
-                # Check if this log record is itself an exception record from Loguru
-                is_internal_loguru_error_log = record_data.get("exception") is not None
-            except (TypeError, KeyError) as e_record_access:
-                # Handles cases where message.record is not a dict or essential keys are missing.
-                # This might happen if Loguru internally logs a message that doesn't conform to the standard record structure.
-                print(f"Loguru gui_sink: Incapaz de processar registro de log não padrão (erro acesso inicial): {message} | Erro: {e_record_access}", file=sys.stderr)
-                return
-
-            try:
-                # --- Streaming to WebSocket queue ---
-                if _gui_logging_enabled and get_log_queue() is not None: # Check _gui_logging_enabled too
-                    # format_log_record is expected to return a serializable dict or None
-                    # It should ideally use record_data which we got above.
-                    # For safety, pass record_data if format_log_record expects the raw record dict
-                    formatted_log_for_ws = format_log_record(record_data)
-
-                    if formatted_log_for_ws is not None:
-                        current_loop = None
-                        try:
-                            current_loop = asyncio.get_event_loop_policy().get_event_loop()
-                        except RuntimeError as e_get_loop: # No loop in current thread
-                            if not is_internal_loguru_error_log:
-                                print(f"Loguru gui_sink (WebSocket): Sem loop asyncio ativo na thread atual para '{record_message_text}'. Erro: {e_get_loop}", file=sys.stderr)
-                                print(f"Loguru gui_sink (Fallback): Missed GUI log from thread without asyncio loop: [{record_data.get('level', {}).get('name', 'UNKNOWN')}] {record_message_text}", file=sys.stderr)
-                                return
-                            # Cannot proceed with queueing if no loop.
-
-                        if current_loop: # If loop was successfully obtained
-                            try:
-                                # Attempt to get the main running loop for thread-safe operations if needed.
-                                main_running_loop = asyncio.get_running_loop()
-
-                                if current_loop is main_running_loop and current_loop.is_running():
-                                    get_log_queue().put_nowait(formatted_log_for_ws)
-                                elif main_running_loop.is_running():
-                                    main_running_loop.call_soon_threadsafe(get_log_queue().put_nowait, formatted_log_for_ws)
-                                else: # Main loop not running, or current_loop is not main and not running.
-                                    if not is_internal_loguru_error_log:
-                                        print(f"Loguru gui_sink (WebSocket): Loop principal/atual do asyncio não está rodando. Log para WebSocket pulado para: '{record_message_text}'", file=sys.stderr)
-
-                            except RuntimeError: # Catches asyncio.get_running_loop() if no loop is set as running
-                                if not is_internal_loguru_error_log:
-                                     print(f"Loguru gui_sink (WebSocket): Loop principal do asyncio não disponível/rodando para log via WebSocket. Log: '{record_message_text}'", file=sys.stderr)
-                            except asyncio.QueueFull:
-                                if not is_internal_loguru_error_log:
-                                    print(f"Loguru gui_sink (WebSocket): Fila de log para GUI cheia. Log de {record_data.get('name', 'N/A')}:{record_data.get('line', 'N/A')} pode ser perdido: '{record_message_text}'", file=sys.stderr)
-                            except Exception as e_ws_put: # Catch other potential errors from put_nowait
-                                if not is_internal_loguru_error_log:
-                                    print(f"Loguru gui_sink (WebSocket): Erro ao colocar log na fila da GUI: {e_ws_put}. Log: '{record_message_text}'", file=sys.stderr)
-                
-                # --- Database logging (mantendo desabilitado como no original, mas com estrutura robusta) ---
-                if _gui_db_logging_enabled: # Check the new flag
-                    # This part is currently disabled in the original code.
-                    # If it were enabled, similar loop handling would be needed.
-                    # For now, we just acknowledge its state.
-                    if False: # Explicitly keeping DB logging disabled
-                        async def write_log_to_db():
-                            # return # Original disablement
-                            async with AsyncSessionLocal() as session:
-                                async with session.begin():
-                                    try:
-                                        db_log_entry = LogEntry(
-                                            timestamp=record_data['time'],
-                                            level=record_data['level'].name,
-                                            message=record_message_text, # Use pre-fetched message
-                                            logger_name=record_data['name'],
-                                            module=record_data['module'],
-                                            function=record_data['function'],
-                                            line=record_data['line'],
-                                            execution_id=record_data['extra'].get("execution_id")
-                                        )
-                                        session.add(db_log_entry)
-                                        await session.commit()
-                                    except Exception as e_db:
-                                        if not is_internal_loguru_error_log:
-                                            print(f"Loguru gui_sink (DB): Erro ao escrever log no BD: {e_db}. Log: '{record_message_text}'", file=sys.stderr)
-                                        await session.rollback()
-
-                        # Logic to call write_log_to_db using appropriate loop (similar to WebSocket)
-                        # This would need careful implementation if DB logging is re-enabled.
-                        # For now, this part remains effectively disabled.
-                        pass # Placeholder if the 'if False' is removed.
-
-            except RuntimeError as e_runtime:
-                # Captura "There is no current event loop in thread" ou "Event loop is closed"
-                # Esta exceção seria mais provável de asyncio.get_event_loop_policy().get_event_loop() se falhar de forma inesperada
-                # ou de asyncio.get_running_loop()
-                if "no current event loop" in str(e_runtime).lower() or "event loop is closed" in str(e_runtime).lower():
-                    if not is_internal_loguru_error_log:
-                        print(f"Loguru gui_sink: Sem loop asyncio ativo ou loop fechado. Log para DB/GUI pulado para: '{record_message_text}'. Erro: {e_runtime}", file=sys.stderr)
-                else:
-                    if not is_internal_loguru_error_log:
-                        print(f"Loguru gui_sink: RuntimeError inesperado: {e_runtime}. Log: '{record_message_text}'", file=sys.stderr)
-            except Exception as e_general:
-                if not is_internal_loguru_error_log:
-                    print(f"Loguru gui_sink: Exceção inesperada ao processar log: {e_general}. Log: '{record_message_text}'", file=sys.stderr)
-
-        _logger.add(gui_sink, level="DEBUG") # Or use logfile_level.
-    # --- End GUI sink ---
+    # GUI related components and sinks have been removed.
 
     return _logger
 
 
 logger = define_log_level()
-
-# asyncio is now imported at the top.
 
 if __name__ == "__main__":
     logger.info("Starting application")


### PR DESCRIPTION
- Revertido app/agent/toolcall.py para o estado original para resolver SyntaxError.
- Removidas referências a componentes de GUI de app/logger.py para evitar conflitos e logs desnecessários.
- Mantidas as seguintes correções anteriores bem-sucedidas:
  - ChecklistManager: Logging de debug para linhas malformadas.
  - EnvironmentValidator: Introduzido para verificações de pré-execução.
  - Exceções: Adicionada AgentEnvironmentError.
  - Manus.think(): Corrigida lógica de duplo reset do checklist.

As modificações para padronizar o retorno de SandboxPythonExecutor e PythonExecute para ToolResult (Ações 1.X.3 e 1.X.4) serão reavaliadas.

**Funcionalidades**
<!-- Descreva as funcionalidades ou correções de bugs neste PR. Para correções de bugs, vincule à issue. -->

- Funcionalidade 1
- Funcionalidade 2

**Documentação da Funcionalidade**
<!-- Forneça links de RFC, tutorial ou caso de uso para atualizações significativas. Opcional para pequenas alterações. -->

**Impacto**
<!-- Explique o impacto dessas alterações para o foco do revisor. -->

**Resultado**
<!-- Inclua capturas de tela ou logs de testes unitários ou resultados de execução. -->

**Outro**
<!-- Notas adicionais sobre este PR. -->
